### PR TITLE
Save 908,288 bytes by deleting 'const' three times

### DIFF
--- a/compact_enc_det/compact_enc_det.cc
+++ b/compact_enc_det/compact_enc_det.cc
@@ -271,9 +271,9 @@ typedef struct {
   uint8 x_stddev;       // Standard deviation of byte2 value
   uint8 y_stddev;       // Standard deviation of byte1 value
   int so;               // Scaling offset -- add to probabilities below
-  const uint8 b1[256];  // Unigram probability for first byte of aligned bigram
-  const uint8 b2[256];  // Unigram probability for second byte of aligned bigram
-  const uint8 b12[256]; // Unigram probability for cross bytes of aligned bigram
+  uint8 b1[256];        // Unigram probability for first byte of aligned bigram
+  uint8 b2[256];        // Unigram probability for second byte of aligned bigram
+  uint8 b12[256];       // Unigram probability for cross bytes of aligned bigram
 } UnigramEntry;
 
 //typedef struct {


### PR DESCRIPTION
Due to an odd VC++ quirk, having const members in a struct that is then
used to define a const array leads to weirdness. The const array ends
up in the read/write segment instead of the read-only segment, and lots
of code is generated to do the initializing. Removing the unnecessary-
but-should-be-harmless 'const' keywords helps the compiler generate the
intended read-only array and saves a lot of code. This change has the
following effect on a full official Win32 Chrome build:

chrome.dll
       .text: -364576 bytes change
      .rdata:  -22624 bytes change
       .data:  -53056 bytes change
      .reloc: -105020 bytes change
Total change: -545276 bytes

File-size saving is 492032 bytes.

chrome_child.dll
       .text: -364592 bytes change
      .rdata:   52960 bytes change
       .data:  -53056 bytes change
      .reloc: -104824 bytes change
Total change: -469512 bytes

File-size saving is 416256 bytes.

Total file-size saving is 908,288 bytes.

The movement of ~53,000 bytes from the .data to .rdata segments in
chrome_child.dll is a reliable consequence of working around this VC++
quirk. The code-size savings is because in this particular instanceVC++
creates a dynamic initializer for 'unigram_table' function which is (for
chrome.dll) 52,063 instructions long, with 51,724 of those instructions
moving a single byte. This also means that this change avoids ~52 KiB
of private data for each Chrome process, by avoiding runtime
initialization of the array.

VC++ bug is filed here:
https://connect.microsoft.com/VisualStudio/feedback/details/3117602

Other instances of this quirk are also being worked around but this is
the most dramatic example.

BUG=677351,629332