### PR TITLE
Fix unittest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ add_library(ced ${CED_LIBRARY_SOURCES})
 #add_definitions(-DHTML5_MODE)
 
 set(GTEST_INCLUDE_DIR "gtest/googletest/include")
-set(GTEST_LIB_DIR "${CMAKE_SOURCE_DIR}/gtest/googlemock/gtest")
+set(GTEST_LIB_DIR "${CMAKE_SOURCE_DIR}/gtest/lib")
 
 set(CED_UNITTEST_SOURCES
     compact_enc_det/compact_enc_det_unittest.cc


### PR DESCRIPTION
`autogen.sh` currently fails to build `libgtest.a`:

```
make[2]: *** No rule to make target 'gtest/googlemock/gtest/libgtest.a', needed by 'bin/ced_unittest'.  Stop.
```

By updating `GTEST_LIB_DIR` to the updated path used by the latest [Google Test](https://github.com/google/googletest), `autogen.sh` works again.