### PR TITLE
Fix compiling on macOS

### DIFF
--- a/compact_enc_det/compact_enc_det.cc
+++ b/compact_enc_det/compact_enc_det.cc
@@ -2208,9 +2208,9 @@ void InitialBytesBoost(const uint8* src,
                        DetectEncodingState* destatep) {
   if (text_length < 4) {return;}
 
-  uint pair01 = (src[0] << 8) | src[1];
-  uint pair23 = (src[2] << 8) | src[3];
-  uint quad0123 = (pair01 << 16) | pair23;
+  uint32 pair01 = (src[0] << 8) | src[1];
+  uint32 pair23 = (src[2] << 8) | src[3];
+  uint32 quad0123 = (pair01 << 16) | pair23;
 
   bool utf_16_indication = false;
   bool utf_32_indication = false;

--- a/compact_enc_det/compact_enc_det_hint_code.cc
+++ b/compact_enc_det/compact_enc_det_hint_code.cc
@@ -109,7 +109,7 @@ string MakeChar44(const string& str) {
   string res("________");     // eight underscores
   int l_ptr = 0;
   int d_ptr = 0;
-  for (uint i = 0; i < str.size(); ++i) {
+  for (uint32 i = 0; i < str.size(); ++i) {
     uint8 uc = static_cast<uint8>(str[i]);
     if (kIsAlpha[uc]) {
       if (l_ptr < 4) {                  // Else ignore
@@ -138,7 +138,7 @@ string MakeChar44(const string& str) {
 string MakeChar4(const string& str) {
   string res("____");     // four underscores
   int l_ptr = 0;
-  for (uint i = 0; i < str.size(); ++i) {
+  for (uint32 i = 0; i < str.size(); ++i) {
     uint8 uc = static_cast<uint8>(str[i]);
     if (kIsAlpha[uc] | kIsDigit[uc]) {
       if (l_ptr < 4) {                  // Else ignore
@@ -156,7 +156,7 @@ string MakeChar4(const string& str) {
 string MakeChar8(const string& str) {
   string res("________");     // eight dots
   int l_ptr = 0;
-  for (uint i = 0; i < str.size(); ++i) {
+  for (uint32 i = 0; i < str.size(); ++i) {
     uint8 uc = static_cast<uint8>(str[i]);
     if (kIsAlpha[uc] | kIsDigit[uc]) {
       if (l_ptr < 8) {                  // Else ignore


### PR DESCRIPTION
https://github.com/google/compact_enc_det/commit/5299bca7727cacad2955cd67fe913d9c44ce9694 introduced the use of `uint` which is not a standard type, however, some compilers specify a typedef of `unsigned int`. Clang on macOS doesn’t, though, which is why compiling on macOS currently fails with the following error message:

```
error: unknown type name 'uint'
```

Using `unsigned int` instead of `uint` fixes this issue.