### PR TITLE
Revert "Save 908,288 bytes by deleting 'const' three times"

### DIFF
--- a/compact_enc_det/compact_enc_det.cc
+++ b/compact_enc_det/compact_enc_det.cc
@@ -268,9 +268,9 @@ typedef struct {
   uint8 x_stddev;       // Standard deviation of byte2 value
   uint8 y_stddev;       // Standard deviation of byte1 value
   int so;               // Scaling offset -- add to probabilities below
-  uint8 b1[256];        // Unigram probability for first byte of aligned bigram
-  uint8 b2[256];        // Unigram probability for second byte of aligned bigram
-  uint8 b12[256];       // Unigram probability for cross bytes of aligned bigram
+  const uint8 b1[256];  // Unigram probability for first byte of aligned bigram
+  const uint8 b2[256];  // Unigram probability for second byte of aligned bigram
+  const uint8 b12[256]; // Unigram probability for cross bytes of aligned bigram
 } UnigramEntry;
 
 //typedef struct {


### PR DESCRIPTION
This reverts commit 9a5abb86e339beca2ad7f375934a38727e810f45. VS is
still working on a fix to the underlying issue but clang-cl doesn't need
this hack so we can remove it.

Bug: 934323