### PR TITLE
Change shebang to sh instead of bash

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 #
 # Copyright 2016 Google Inc.
 #


### PR DESCRIPTION
This PR changes the shebang in the `autogen.sh` from bash to sh, as using bash can cause troubles on systems without bash (like Alpine). I'm also using the `#!/usr/bin/env sh` syntax to use the user configured default shell instead of the hardcoded `/bin/sh` path.

It should cause no issues as there is not anything bash-specific in the `autogen.sh` source.

Related to #22.